### PR TITLE
Use scaled result timer for phase deadline

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -178,7 +178,7 @@ function finishRound() {
     const playerCount = Object.keys(players).length;
     const scaledResultTimer = getScaledResultTimer(playerCount); // Calculate how long to show results.
 
-    phaseDeadlineMs = Date.now() + resultTimer; // Set the deadline for the results phase.
+    phaseDeadlineMs = Date.now() + scaledResultTimer; // Set the deadline for the results phase.
     lastVotes = votes; // Cache the votes for late-joiners.
 
     // Send the round results to all players in the 'game' room.


### PR DESCRIPTION
## Summary
- use `scaledResultTimer` to set the results-phase deadline so its duration scales with player count

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const getScaledResultTimer=..."` *(verified phaseDeadlineMs uses scaledResultTimer)*

------
https://chatgpt.com/codex/tasks/task_e_6898fe9b398c8320813bc17930da9cda