### PR TITLE
Inline replaced question in startNextRound

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -144,14 +144,14 @@ function startNextRound() {
 
     const playersList = Object.values(players);
     // If the question contains a placeholder, replace it with a player's name.
-    const questionWithName = replacePlayerNamePlaceholder(currentQuestion, playersList);
+    currentQuestion = replacePlayerNamePlaceholder(currentQuestion, playersList);
 
     phaseDeadlineMs = Date.now() + questionTimer; // Set the deadline for answering.
     playersList.forEach(p => (p.currentVote = null)); // Reset all player votes.
 
     // Send the new question and round information to all players in the 'game' room.
     io.to('game').emit('new-question', {
-        question: questionWithName,
+        question: currentQuestion,
         players: playersList.map(p => ({ name: p.name, color: p.color })),
         votesCount: 0,
         timeRemaining: timeRemaining()


### PR DESCRIPTION
## Summary
- Inline `replacePlayerNamePlaceholder` result into `currentQuestion`
- Remove temporary `questionWithName` variable in `startNextRound`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689900c523088320963a19f2d3cc27ea